### PR TITLE
RecoveryTotem 1.0.1

### DIFF
--- a/RecoveryTotem/pom.xml
+++ b/RecoveryTotem/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.poorgrammerdev</groupId>
     <artifactId>RecoveryTotem</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <name>RecoveryTotem</name>

--- a/RecoveryTotem/src/main/java/io/github/poorgrammerdev/recoverytotem/TotemMechanism.java
+++ b/RecoveryTotem/src/main/java/io/github/poorgrammerdev/recoverytotem/TotemMechanism.java
@@ -19,40 +19,99 @@ import org.bukkit.inventory.ItemStack;
 public class TotemMechanism implements Listener {
     private final RecoveryTotem plugin;
     
+    private final boolean dropOtherRecoveryTotemsOnDeath;
+    
     public TotemMechanism(RecoveryTotem plugin) {
         this.plugin = plugin;
+
+        this.dropOtherRecoveryTotemsOnDeath = plugin.getConfig().getBoolean("drop_other_recovery_totems_on_death", false);
     }
 
     @EventHandler(ignoreCancelled = true)
     public void onDeath(final PlayerDeathEvent event) {
+        if (this.dropOtherRecoveryTotemsOnDeath) {
+            this.mechanismWithDuplicateDrop(event);
+        }
+        else {
+            this.mechanismWithoutDuplicateDrop(event);
+        }
+    }
+
+    /**
+     * Default behavior: simply destroy one Totem and keep inventory
+     * @param event
+     */
+    private void mechanismWithoutDuplicateDrop(final PlayerDeathEvent event) {
         final Player player = event.getEntity();
         
         for (final ItemStack item : player.getInventory()) {
             if (this.plugin.isTotem(item)) {
-                //Keep items
-                event.setKeepInventory(true);
-                event.getDrops().clear();
+                this.onFindRecoveryTotem(event);
 
-                //Keep EXP
-                event.setKeepLevel(true);
-                event.setDroppedExp(0);
-                
                 //Remove the used totem
                 item.setAmount(item.getAmount() - 1);
-
-                //Play effects and return
-                final World world = player.getWorld();
-                final Location location = player.getEyeLocation();
-                world.playSound(location, Sound.ITEM_TOTEM_USE, SoundCategory.PLAYERS, 1, 0.75F);
-                world.spawnParticle(Particle.BLOCK, location, 50, 0.5, 0.5, 0.5, 0, Material.SCULK.createBlockData());
-                world.spawnParticle(Particle.BLOCK, location, 50, 0.5, 0.5, 0.5, 0, Material.SOUL_FIRE.createBlockData());
                 return;
             }
         }
     }
 
+    /**
+     * Modified behavior: destroy one Totem, drop other Totems, and keep other items
+     */
+    private void mechanismWithDuplicateDrop(final PlayerDeathEvent event) {
+        final Player player = event.getEntity();
 
+        boolean encounteredRecoveryTotem = false;
+        for (final ItemStack item : player.getInventory()) {
+            if (this.plugin.isTotem(item)) {
+                //First totem encountered
+                if (!encounteredRecoveryTotem) {
+                    this.onFindRecoveryTotem(event);
 
+                    //Remove the used totem
+                    final int amountToDrop = item.getAmount() - 1;
+                    
+                    //If totem was somehow a stack, drop the rest of the stack
+                    if (amountToDrop > 0) {
+                        final ItemStack droppedTotem = item.clone();
+                        droppedTotem.setAmount(amountToDrop);
+                        event.getDrops().add(droppedTotem);
+                    }
+                    
+                    item.setAmount(0);
+                    encounteredRecoveryTotem = true;
+                }
+                
+                //Drop all other Recovery Totems
+                else {
+                    event.getDrops().add(item.clone());
+                    item.setAmount(0);
+                }
 
+            }
+        }
+    }
+
+    /**
+     * Handles keeping inventory and effects on finding a Recovery Totem on death
+     */
+    private void onFindRecoveryTotem(final PlayerDeathEvent event) {
+        final Player player = event.getEntity();
+
+        //Keep items
+        event.setKeepInventory(true);
+        event.getDrops().clear();
+    
+        //Keep EXP
+        event.setKeepLevel(true);
+        event.setDroppedExp(0);
+
+        //Play effects and return
+        final World world = player.getWorld();
+        final Location location = player.getEyeLocation();
+        world.playSound(location, Sound.ITEM_TOTEM_USE, SoundCategory.PLAYERS, 1, 0.75F);
+        world.spawnParticle(Particle.BLOCK, location, 50, 0.5, 0.5, 0.5, 0, Material.SCULK.createBlockData());
+        world.spawnParticle(Particle.BLOCK, location, 50, 0.5, 0.5, 0.5, 0, Material.SOUL_FIRE.createBlockData());
+    }
 
 }

--- a/RecoveryTotem/src/main/resources/config.yml
+++ b/RecoveryTotem/src/main/resources/config.yml
@@ -15,3 +15,7 @@ write_description: true
 # The field can be any type, any value. As long as it exists on the item, it will be rejected.
 external_item_keys: {}
 
+# By default (false), the player will destroy one Totem of Recovery and keep all other items, including other Totems of Recovery.
+# If this is set to true, the player will still destroy one Totem of Recovery and keep all of their other items.
+#  However, if they were carrying more Totems of Recovery, those will be dropped where they died.
+drop_other_recovery_totems_on_death: false


### PR DESCRIPTION
Added a config option for players to not keep other Recovery Totems through respawn
 - As per usual, one totem will be destroyed
 - However, the remaining totems will drop where they died
 - This is disabled by default, so the default behavior has not changed